### PR TITLE
Update URL for Javadoc badge's image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # conversations
 [![Build Status](https://api.travis-ci.org/maximilientyc/conversations.svg)](https://travis-ci.org/maximilientyc/conversations)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.maximilientyc/conversations/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.maximilientyc/conversations)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.github.maximilientyc/conversations/badge.svg)](http://www.javadoc.io/doc/com.github.maximilientyc/conversations)
+[![Javadoc](https://javadoc.io/badge/com.github.maximilientyc/conversations.svg)](http://www.javadoc.io/doc/com.github.maximilientyc/conversations)


### PR DESCRIPTION
OpenShit Online V2 is closed and this domain is not accessible anymore.
And javadoc.io introduce badges hosted directly on javadoc.io